### PR TITLE
Fix the CS SPI line management

### DIFF
--- a/cs-pin-write/patch.cpp
+++ b/cs-pin-write/patch.cpp
@@ -10,11 +10,12 @@ void evaluate(Context ctx) {
         emitValue<output_DEVU0027>(ctx, dev);
     }
 
-    if (!isInputDirty<input_DO>(ctx))
+    if (!isInputDirty<input_UPD>(ctx))
         return;
 
-    uint8_t data = getValue<input_DATA>(ctx);
-    shiftOut(dev->pinMOSI, dev->pinSCK, MSBFIRST, data);
+    const bool val = getValue<input_SIG>(ctx);
+
+    ::digitalWrite(dev->pinCS, val);
 
     emitValue<output_DONE>(ctx, 1);
 }

--- a/cs-pin-write/patch.xodp
+++ b/cs-pin-write/patch.xodp
@@ -1,0 +1,81 @@
+{
+  "description": "Sets the state (\"on\" or \"off\") for the CS pin Octofet is connected to.",
+  "nodes": [
+    {
+      "id": "BJMSJ9L3kP",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "State to write",
+      "id": "BkxHk5I2kw",
+      "label": "SIG",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "description": "Fires on writing complete",
+      "id": "ByXryqU2JD",
+      "label": "DONE",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "The Octofet device",
+      "id": "H1ouY83Jw",
+      "label": "DEV'",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "@/output-octofet-device"
+    },
+    {
+      "description": "The Octofet device",
+      "id": "H1tOYU2kP",
+      "label": "DEV",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-octofet-device"
+    },
+    {
+      "id": "r1H_F83kD",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/utility"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "Continuously"
+      },
+      "description": "Triggers new write",
+      "id": "rkrkq821v",
+      "label": "UPD",
+      "position": {
+        "units": "slots",
+        "x": 4,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    }
+  ]
+}

--- a/example-2-in-chain/patch.xodp
+++ b/example-2-in-chain/patch.xodp
@@ -187,7 +187,7 @@
       "position": {
         "units": "slots",
         "x": 14,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -199,7 +199,7 @@
       "position": {
         "units": "slots",
         "x": 18,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -211,7 +211,7 @@
       "position": {
         "units": "slots",
         "x": 11,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -223,7 +223,7 @@
       "position": {
         "units": "slots",
         "x": 15,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -235,7 +235,7 @@
       "position": {
         "units": "slots",
         "x": 6,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -247,7 +247,7 @@
       "position": {
         "units": "slots",
         "x": 8,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -261,7 +261,7 @@
       "position": {
         "units": "slots",
         "x": 0,
-        "y": 0.75
+        "y": 1
       },
       "type": "@/octofet-16"
     },
@@ -273,7 +273,7 @@
       "position": {
         "units": "slots",
         "x": 12,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -285,7 +285,7 @@
       "position": {
         "units": "slots",
         "x": 17,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -297,7 +297,7 @@
       "position": {
         "units": "slots",
         "x": 16,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -309,7 +309,7 @@
       "position": {
         "units": "slots",
         "x": 10,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -321,7 +321,7 @@
       "position": {
         "units": "slots",
         "x": 3,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -333,7 +333,7 @@
       "position": {
         "units": "slots",
         "x": 4,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -345,7 +345,7 @@
       "position": {
         "units": "slots",
         "x": 9,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -357,7 +357,7 @@
       "position": {
         "units": "slots",
         "x": 7,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -369,7 +369,7 @@
       "position": {
         "units": "slots",
         "x": 5,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     },
@@ -381,7 +381,7 @@
       "position": {
         "units": "slots",
         "x": 13,
-        "y": -0.25
+        "y": 0
       },
       "type": "xod/debug/tweak-boolean"
     }

--- a/octofet-16/patch.xodp
+++ b/octofet-16/patch.xodp
@@ -2,17 +2,6 @@
   "description": "Represents two Octofet boards connected in a daisy-chain.",
   "links": [
     {
-      "id": "B1D7NnsvU",
-      "input": {
-        "nodeId": "r1ZFgmniPU",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "B1c2XQniwL",
-        "pinKey": "BJeAFkniwU"
-      }
-    },
-    {
       "id": "B1Ketgm3ovI",
       "input": {
         "nodeId": "Sy6YeXniD8",
@@ -32,6 +21,17 @@
       "output": {
         "nodeId": "BkiKgm3iv8",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BJDns8nyw",
+      "input": {
+        "nodeId": "r1ZFgmniPU",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "SkZsoU2JD",
+        "pinKey": "ByXryqU2JD"
       }
     },
     {
@@ -76,6 +76,17 @@
       "output": {
         "nodeId": "Hk3tx73owL",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ByghsI3Jw",
+      "input": {
+        "nodeId": "HkCKxX2sv8",
+        "pinKey": "HJN0K13jPU"
+      },
+      "output": {
+        "nodeId": "S1qqsUhyv",
+        "pinKey": "H1ouY83Jw"
       }
     },
     {
@@ -156,6 +167,28 @@
       }
     },
     {
+      "id": "HkSnsI2yv",
+      "input": {
+        "nodeId": "SkZsoU2JD",
+        "pinKey": "rkrkq821v"
+      },
+      "output": {
+        "nodeId": "B1c2XQniwL",
+        "pinKey": "BJeAFkniwU"
+      }
+    },
+    {
+      "id": "Hkaos83Jv",
+      "input": {
+        "nodeId": "S1qqsUhyv",
+        "pinKey": "H1tOYU2kP"
+      },
+      "output": {
+        "nodeId": "rkQFgm2iPI",
+        "pinKey": "HkwwE5JwU"
+      }
+    },
+    {
       "id": "HkpnQ73jw8",
       "input": {
         "nodeId": "BytnmmhoDU",
@@ -196,6 +229,17 @@
       },
       "output": {
         "nodeId": "S1VKlQ2sP8",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "S1ussU2Jv",
+      "input": {
+        "nodeId": "S1qqsUhyv",
+        "pinKey": "rkrkq821v"
+      },
+      "output": {
+        "nodeId": "rJbW8E2ivU",
         "pinKey": "__out__"
       }
     },
@@ -244,17 +288,6 @@
       }
     },
     {
-      "id": "SyGbIV2jDU",
-      "input": {
-        "nodeId": "HkCKxX2sv8",
-        "pinKey": "rkK0t1hjvU"
-      },
-      "output": {
-        "nodeId": "rJbW8E2ivU",
-        "pinKey": "__out__"
-      }
-    },
-    {
       "id": "Syly42ovI",
       "input": {
         "nodeId": "BJXiqm2jvL",
@@ -274,6 +307,17 @@
       "output": {
         "nodeId": "HkCKxX2sv8",
         "pinKey": "rkoYaT3P8"
+      }
+    },
+    {
+      "id": "r17hoL3kw",
+      "input": {
+        "nodeId": "HkCKxX2sv8",
+        "pinKey": "rkK0t1hjvU"
+      },
+      "output": {
+        "nodeId": "S1qqsUhyv",
+        "pinKey": "ByXryqU2JD"
       }
     },
     {
@@ -321,17 +365,6 @@
       }
     },
     {
-      "id": "rJmeMMTvU",
-      "input": {
-        "nodeId": "HkCKxX2sv8",
-        "pinKey": "HJN0K13jPU"
-      },
-      "output": {
-        "nodeId": "rkQFgm2iPI",
-        "pinKey": "HkwwE5JwU"
-      }
-    },
-    {
       "id": "rJseYxXnsP8",
       "input": {
         "nodeId": "HkCKxX2sv8",
@@ -376,6 +409,17 @@
       }
     },
     {
+      "id": "ryW2sUn1w",
+      "input": {
+        "nodeId": "SkZsoU2JD",
+        "pinKey": "H1tOYU2kP"
+      },
+      "output": {
+        "nodeId": "B1c2XQniwL",
+        "pinKey": "rkoYaT3P8"
+      }
+    },
+    {
       "id": "ryeZ8VhjwI",
       "input": {
         "nodeId": "HkbIVnsPL",
@@ -394,7 +438,7 @@
       "label": "CH5",
       "position": {
         "units": "slots",
-        "x": 12,
+        "x": 15,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -403,7 +447,7 @@
       "id": "B1c2XQniwL",
       "position": {
         "units": "slots",
-        "x": 18,
+        "x": 14,
         "y": 6
       },
       "type": "@/write-byte"
@@ -444,7 +488,7 @@
       "label": "CH6",
       "position": {
         "units": "slots",
-        "x": 13,
+        "x": 16,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -455,7 +499,7 @@
       "label": "CH2",
       "position": {
         "units": "slots",
-        "x": 9,
+        "x": 12,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -469,7 +513,7 @@
       "label": "ACT",
       "position": {
         "units": "slots",
-        "x": 30,
+        "x": 28,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -480,7 +524,7 @@
       "label": "CH1",
       "position": {
         "units": "slots",
-        "x": 8,
+        "x": 11,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -491,7 +535,7 @@
       "label": "MOSI",
       "position": {
         "units": "slots",
-        "x": 3,
+        "x": 7,
         "y": 0
       },
       "type": "xod/patch-nodes/input-port"
@@ -533,7 +577,7 @@
       "label": "CH3",
       "position": {
         "units": "slots",
-        "x": 10,
+        "x": 13,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -542,7 +586,7 @@
       "id": "HkCKxX2sv8",
       "position": {
         "units": "slots",
-        "x": 6,
+        "x": 10,
         "y": 6
       },
       "type": "@/write-byte"
@@ -558,6 +602,7 @@
     },
     {
       "id": "HkbIVnsPL",
+      "label": "UPD",
       "position": {
         "units": "slots",
         "x": 27,
@@ -593,7 +638,7 @@
       "label": "SCK",
       "position": {
         "units": "slots",
-        "x": 4,
+        "x": 8,
         "y": 0
       },
       "type": "xod/patch-nodes/input-port"
@@ -604,10 +649,19 @@
       "label": "CH0",
       "position": {
         "units": "slots",
-        "x": 7,
+        "x": 10,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "S1qqsUhyv",
+      "position": {
+        "units": "slots",
+        "x": 6,
+        "y": 6
+      },
+      "type": "@/cs-pin-write"
     },
     {
       "id": "SJo9Q2sPI",
@@ -619,10 +673,22 @@
       "type": "xod/core/gate"
     },
     {
+      "boundLiterals": {
+        "BkxHk5I2kw": "True"
+      },
+      "id": "SkZsoU2JD",
+      "position": {
+        "units": "slots",
+        "x": 18,
+        "y": 6
+      },
+      "type": "@/cs-pin-write"
+    },
+    {
       "id": "Sy6YeXniD8",
       "position": {
         "units": "slots",
-        "x": 7,
+        "x": 10,
         "y": 2
       },
       "type": "@/pack-bools-to-byte"
@@ -633,7 +699,7 @@
       "label": "CH7",
       "position": {
         "units": "slots",
-        "x": 14,
+        "x": 17,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -666,7 +732,7 @@
       "label": "CH4",
       "position": {
         "units": "slots",
-        "x": 11,
+        "x": 14,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -684,6 +750,7 @@
     },
     {
       "id": "rJbW8E2ivU",
+      "label": "UPD",
       "position": {
         "units": "slots",
         "x": 8,
@@ -697,7 +764,7 @@
       "label": "CS",
       "position": {
         "units": "slots",
-        "x": 2,
+        "x": 6,
         "y": 0
       },
       "type": "xod/patch-nodes/input-port"
@@ -717,7 +784,7 @@
       "id": "rkQFgm2iPI",
       "position": {
         "units": "slots",
-        "x": 2,
+        "x": 6,
         "y": 2
       },
       "type": "@/octofet-device"

--- a/octofet-24/patch.xodp
+++ b/octofet-24/patch.xodp
@@ -24,17 +24,6 @@
       }
     },
     {
-      "id": "B1fi1rAjwL",
-      "input": {
-        "nodeId": "SJiJSRoDI",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "H1likrCsDU",
-        "pinKey": "BJeAFkniwU"
-      }
-    },
-    {
       "id": "B1gzSDQAiPI",
       "input": {
         "nodeId": "BJweHvQRswL",
@@ -54,6 +43,17 @@
       "output": {
         "nodeId": "HyHwmAiw8",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "B1nm2LhJP",
+      "input": {
+        "nodeId": "SJRHwX0svU",
+        "pinKey": "HJN0K13jPU"
+      },
+      "output": {
+        "nodeId": "HkYX2Uhyw",
+        "pinKey": "H1ouY83Jw"
       }
     },
     {
@@ -123,6 +123,17 @@
       }
     },
     {
+      "id": "BJzEhL2yw",
+      "input": {
+        "nodeId": "HkYX2Uhyw",
+        "pinKey": "rkrkq821v"
+      },
+      "output": {
+        "nodeId": "ryZ-HvmAsP8",
+        "pinKey": "__out__"
+      }
+    },
+    {
       "id": "By1-bMTw8",
       "input": {
         "nodeId": "SJ_xBDQAsD8",
@@ -142,6 +153,17 @@
       "output": {
         "nodeId": "SyceSvQCsPI",
         "pinKey": "ByHmL0uHPk-"
+      }
+    },
+    {
+      "id": "ByWS2InyP",
+      "input": {
+        "nodeId": "BJkS3I3Jw",
+        "pinKey": "rkrkq821v"
+      },
+      "output": {
+        "nodeId": "H1likrCsDU",
+        "pinKey": "BJeAFkniwU"
       }
     },
     {
@@ -200,17 +222,6 @@
       }
     },
     {
-      "id": "HySmrDQCiDL",
-      "input": {
-        "nodeId": "SJRHwX0svU",
-        "pinKey": "rkK0t1hjvU"
-      },
-      "output": {
-        "nodeId": "ryZ-HvmAsP8",
-        "pinKey": "__out__"
-      }
-    },
-    {
       "id": "HymGBwQCoPI",
       "input": {
         "nodeId": "BJweHvQRswL",
@@ -219,6 +230,17 @@
       "output": {
         "nodeId": "HJXeSPQRivL",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "S17H3U31P",
+      "input": {
+        "nodeId": "SJiJSRoDI",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "BJkS3I3Jw",
+        "pinKey": "ByXryqU2JD"
       }
     },
     {
@@ -277,10 +299,10 @@
       }
     },
     {
-      "id": "SJu1ZzpvI",
+      "id": "Sk5mnU2JP",
       "input": {
-        "nodeId": "SJRHwX0svU",
-        "pinKey": "HJN0K13jPU"
+        "nodeId": "HkYX2Uhyw",
+        "pinKey": "H1tOYU2kP"
       },
       "output": {
         "nodeId": "rJ7rvmCjPL",
@@ -365,6 +387,17 @@
       }
     },
     {
+      "id": "SygNn83yD",
+      "input": {
+        "nodeId": "SJRHwX0svU",
+        "pinKey": "rkK0t1hjvU"
+      },
+      "output": {
+        "nodeId": "HkYX2Uhyw",
+        "pinKey": "ByXryqU2JD"
+      }
+    },
+    {
       "id": "SypbHvX0swU",
       "input": {
         "nodeId": "SkTHPm0sPI",
@@ -439,6 +472,17 @@
       "output": {
         "nodeId": "rkjBv7RoDU",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rkgB38hkv",
+      "input": {
+        "nodeId": "BJkS3I3Jw",
+        "pinKey": "H1tOYU2kP"
+      },
+      "output": {
+        "nodeId": "H1likrCsDU",
+        "pinKey": "rkoYaT3P8"
       }
     },
     {
@@ -537,16 +581,28 @@
       "label": "CH11",
       "position": {
         "units": "slots",
-        "x": 21,
+        "x": 16,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
     },
     {
+      "boundLiterals": {
+        "BkxHk5I2kw": "True"
+      },
+      "id": "BJkS3I3Jw",
+      "position": {
+        "units": "slots",
+        "x": 16,
+        "y": 5
+      },
+      "type": "@/cs-pin-write"
+    },
+    {
       "id": "BJweHvQRswL",
       "position": {
         "units": "slots",
-        "x": 18,
+        "x": 13,
         "y": 2
       },
       "type": "@/pack-bools-to-byte"
@@ -557,7 +613,7 @@
       "label": "CH14",
       "position": {
         "units": "slots",
-        "x": 24,
+        "x": 19,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -568,7 +624,7 @@
       "label": "CH4",
       "position": {
         "units": "slots",
-        "x": 10,
+        "x": 8,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -579,7 +635,7 @@
       "label": "CH20",
       "position": {
         "units": "slots",
-        "x": 34,
+        "x": 26,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -588,7 +644,7 @@
       "id": "H1PMyNRjD8",
       "position": {
         "units": "slots",
-        "x": 30,
+        "x": 22,
         "y": 2
       },
       "type": "@/pack-bools-to-byte"
@@ -597,7 +653,7 @@
       "id": "H1likrCsDU",
       "position": {
         "units": "slots",
-        "x": 29,
+        "x": 12,
         "y": 5
       },
       "type": "@/write-byte"
@@ -619,7 +675,7 @@
       "label": "CH9",
       "position": {
         "units": "slots",
-        "x": 19,
+        "x": 14,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -628,8 +684,8 @@
       "id": "HJKxSDmAiwI",
       "position": {
         "units": "slots",
-        "x": 40,
-        "y": 7
+        "x": 30,
+        "y": 6
       },
       "type": "xod/core/gate"
     },
@@ -639,19 +695,10 @@
       "label": "CH12",
       "position": {
         "units": "slots",
-        "x": 22,
+        "x": 17,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
-    },
-    {
-      "id": "HJqGQGpwI",
-      "position": {
-        "units": "slots",
-        "x": -1,
-        "y": 4
-      },
-      "type": "xod-dev/sharp-irm/gp2y0a41-range-meter"
     },
     {
       "description": "Channel #5 on Octofet #1.",
@@ -659,10 +706,19 @@
       "label": "CH21",
       "position": {
         "units": "slots",
-        "x": 35,
+        "x": 27,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "HkYX2Uhyw",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 5
+      },
+      "type": "@/cs-pin-write"
     },
     {
       "description": "Channel #2 on Octofet #3.",
@@ -670,7 +726,7 @@
       "label": "CH2",
       "position": {
         "units": "slots",
-        "x": 8,
+        "x": 6,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -681,7 +737,7 @@
       "label": "CH6",
       "position": {
         "units": "slots",
-        "x": 12,
+        "x": 10,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -692,7 +748,7 @@
       "label": "CH19",
       "position": {
         "units": "slots",
-        "x": 33,
+        "x": 25,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -703,7 +759,7 @@
       "label": "CH8",
       "position": {
         "units": "slots",
-        "x": 18,
+        "x": 13,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -712,7 +768,7 @@
       "id": "S10L4RiDI",
       "position": {
         "units": "slots",
-        "x": 38,
+        "x": 28,
         "y": 4
       },
       "type": "xod/core/pulse-on-change"
@@ -723,7 +779,7 @@
       "label": "CH10",
       "position": {
         "units": "slots",
-        "x": 20,
+        "x": 15,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -734,7 +790,7 @@
       "label": "CH22",
       "position": {
         "units": "slots",
-        "x": 36,
+        "x": 28,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -745,7 +801,7 @@
       "label": "CH16",
       "position": {
         "units": "slots",
-        "x": 30,
+        "x": 22,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -756,7 +812,7 @@
       "label": "CH17",
       "position": {
         "units": "slots",
-        "x": 31,
+        "x": 23,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -765,7 +821,7 @@
       "id": "SJRHwX0svU",
       "position": {
         "units": "slots",
-        "x": 5,
+        "x": 4,
         "y": 5
       },
       "type": "@/write-byte"
@@ -776,7 +832,7 @@
       "label": "CH23",
       "position": {
         "units": "slots",
-        "x": 37,
+        "x": 29,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -785,7 +841,7 @@
       "id": "SJ_xBDQAsD8",
       "position": {
         "units": "slots",
-        "x": 17,
+        "x": 8,
         "y": 5
       },
       "type": "@/write-byte"
@@ -796,7 +852,7 @@
       "label": "ACK",
       "position": {
         "units": "slots",
-        "x": 30,
+        "x": 17,
         "y": 6
       },
       "type": "xod/patch-nodes/output-pulse"
@@ -818,7 +874,7 @@
       "label": "CH3",
       "position": {
         "units": "slots",
-        "x": 9,
+        "x": 7,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -827,7 +883,7 @@
       "id": "SkTHPm0sPI",
       "position": {
         "units": "slots",
-        "x": 6,
+        "x": 4,
         "y": 2
       },
       "type": "@/pack-bools-to-byte"
@@ -838,7 +894,7 @@
       "label": "CH15",
       "position": {
         "units": "slots",
-        "x": 25,
+        "x": 20,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -849,7 +905,7 @@
       "label": "CH1",
       "position": {
         "units": "slots",
-        "x": 7,
+        "x": 5,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -859,7 +915,7 @@
       "id": "SyceSvQCsPI",
       "position": {
         "units": "slots",
-        "x": 36,
+        "x": 26,
         "y": 5
       },
       "type": "xod/core/any"
@@ -870,7 +926,7 @@
       "label": "CH5",
       "position": {
         "units": "slots",
-        "x": 11,
+        "x": 9,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -881,7 +937,7 @@
       "label": "CH0",
       "position": {
         "units": "slots",
-        "x": 6,
+        "x": 4,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -892,7 +948,7 @@
       "label": "CH13",
       "position": {
         "units": "slots",
-        "x": 23,
+        "x": 18,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -903,7 +959,7 @@
       "label": "CH18",
       "position": {
         "units": "slots",
-        "x": 32,
+        "x": 24,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -914,7 +970,7 @@
       "label": "CH7",
       "position": {
         "units": "slots",
-        "x": 13,
+        "x": 11,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
@@ -932,7 +988,7 @@
       "id": "rJheBDmRsPI",
       "position": {
         "units": "slots",
-        "x": 37,
+        "x": 27,
         "y": 4
       },
       "type": "xod/core/pulse-on-change"
@@ -941,7 +997,7 @@
       "id": "rJixrvmRiD8",
       "position": {
         "units": "slots",
-        "x": 39,
+        "x": 29,
         "y": 4
       },
       "type": "xod/core/boot"
@@ -950,17 +1006,18 @@
       "id": "rk6xBwQCsDI",
       "position": {
         "units": "slots",
-        "x": 36,
+        "x": 26,
         "y": 4
       },
       "type": "xod/core/pulse-on-change"
     },
     {
       "id": "rkMZHwXCsD8",
+      "label": "UPD",
       "position": {
         "units": "slots",
-        "x": 40,
-        "y": 8
+        "x": 30,
+        "y": 7
       },
       "type": "xod/patch-nodes/to-bus"
     },
@@ -984,16 +1041,17 @@
       "label": "ACT",
       "position": {
         "units": "slots",
-        "x": 42,
+        "x": 31,
         "y": 0
       },
       "type": "xod/patch-nodes/input-boolean"
     },
     {
       "id": "ryZ-HvmAsP8",
+      "label": "UPD",
       "position": {
         "units": "slots",
-        "x": 7,
+        "x": 2,
         "y": 4
       },
       "type": "xod/patch-nodes/from-bus"

--- a/octofet/patch.xodp
+++ b/octofet/patch.xodp
@@ -2,6 +2,17 @@
   "description": "The quick start node that represents the Octofet board, \nwhich sets the state (\"on\" or \"off\") of all 8 power switches (a.k.a. «channels»).",
   "links": [
     {
+      "id": "B17Pi8nJD",
+      "input": {
+        "nodeId": "r1ZkM2jvI",
+        "pinKey": "rkK0t1hjvU"
+      },
+      "output": {
+        "nodeId": "B1rLs8nkD",
+        "pinKey": "ByXryqU2JD"
+      }
+    },
+    {
       "id": "B1IabniwL",
       "input": {
         "nodeId": "Bkvi-2iDI",
@@ -24,6 +35,28 @@
       }
     },
     {
+      "id": "B1MvjU3yP",
+      "input": {
+        "nodeId": "B1rLs8nkD",
+        "pinKey": "rkrkq821v"
+      },
+      "output": {
+        "nodeId": "ryFmfhivI",
+        "pinKey": "H1fx68wzB"
+      }
+    },
+    {
+      "id": "B1TUiUhyD",
+      "input": {
+        "nodeId": "B1rLs8nkD",
+        "pinKey": "H1tOYU2kP"
+      },
+      "output": {
+        "nodeId": "H1piSq1wL",
+        "pinKey": "HkwwE5JwU"
+      }
+    },
+    {
       "id": "B1shWnovL",
       "input": {
         "nodeId": "Bkvi-2iDI",
@@ -35,6 +68,39 @@
       }
     },
     {
+      "id": "ByUvsIh1P",
+      "input": {
+        "nodeId": "BkutN85kPL",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "Bkd8iInkD",
+        "pinKey": "ByXryqU2JD"
+      }
+    },
+    {
+      "id": "HJVPsI21D",
+      "input": {
+        "nodeId": "Bkd8iInkD",
+        "pinKey": "rkrkq821v"
+      },
+      "output": {
+        "nodeId": "r1ZkM2jvI",
+        "pinKey": "BJeAFkniwU"
+      }
+    },
+    {
+      "id": "HJiIs83kD",
+      "input": {
+        "nodeId": "Bkd8iInkD",
+        "pinKey": "H1tOYU2kP"
+      },
+      "output": {
+        "nodeId": "r1ZkM2jvI",
+        "pinKey": "rkoYaT3P8"
+      }
+    },
+    {
       "id": "HJsyznswL",
       "input": {
         "nodeId": "r1ZkM2jvI",
@@ -43,17 +109,6 @@
       "output": {
         "nodeId": "Bkvi-2iDI",
         "pinKey": "HklS_IoP8"
-      }
-    },
-    {
-      "id": "HkLgMhjwL",
-      "input": {
-        "nodeId": "r1ZkM2jvI",
-        "pinKey": "HJN0K13jPU"
-      },
-      "output": {
-        "nodeId": "H1piSq1wL",
-        "pinKey": "HkwwE5JwU"
       }
     },
     {
@@ -79,17 +134,6 @@
       }
     },
     {
-      "id": "S1I4M3ovI",
-      "input": {
-        "nodeId": "r1ZkM2jvI",
-        "pinKey": "rkK0t1hjvU"
-      },
-      "output": {
-        "nodeId": "ryFmfhivI",
-        "pinKey": "H1fx68wzB"
-      }
-    },
-    {
       "id": "SJbTbhjw8",
       "input": {
         "nodeId": "Bkvi-2iDI",
@@ -112,17 +156,6 @@
       }
     },
     {
-      "id": "Sy9gMhoDU",
-      "input": {
-        "nodeId": "BkutN85kPL",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "r1ZkM2jvI",
-        "pinKey": "BJeAFkniwU"
-      }
-    },
-    {
       "id": "SyCsS5Jw8",
       "input": {
         "nodeId": "H1piSq1wL",
@@ -142,6 +175,17 @@
       "output": {
         "nodeId": "ry-PcXIsv8",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "r19Uo8hkv",
+      "input": {
+        "nodeId": "r1ZkM2jvI",
+        "pinKey": "HJN0K13jPU"
+      },
+      "output": {
+        "nodeId": "B1rLs8nkD",
+        "pinKey": "H1ouY83Jw"
       }
     },
     {
@@ -202,6 +246,15 @@
       "type": "xod/patch-nodes/input-boolean"
     },
     {
+      "id": "B1rLs8nkD",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 1
+      },
+      "type": "@/cs-pin-write"
+    },
+    {
       "description": "Channel #2 on Octofet.",
       "id": "BkbYVIcJPU",
       "label": "CH2",
@@ -213,12 +266,24 @@
       "type": "xod/patch-nodes/input-boolean"
     },
     {
+      "boundLiterals": {
+        "BkxHk5I2kw": "True"
+      },
+      "id": "Bkd8iInkD",
+      "position": {
+        "units": "slots",
+        "x": 11,
+        "y": 1
+      },
+      "type": "@/cs-pin-write"
+    },
+    {
       "description": "Fires on writing complete.\n",
       "id": "BkutN85kPL",
       "label": "ACK",
       "position": {
         "units": "slots",
-        "x": 6,
+        "x": 12,
         "y": 3
       },
       "type": "xod/patch-nodes/output-pulse"
@@ -247,8 +312,8 @@
       "id": "H1piSq1wL",
       "position": {
         "units": "slots",
-        "x": 1,
-        "y": 0
+        "x": 3,
+        "y": -2
       },
       "type": "@/octofet-device"
     },
@@ -302,8 +367,8 @@
       "label": "SCK",
       "position": {
         "units": "slots",
-        "x": 3,
-        "y": -2
+        "x": 5,
+        "y": -4
       },
       "type": "xod/patch-nodes/input-port"
     },
@@ -313,8 +378,8 @@
       "label": "MOSI",
       "position": {
         "units": "slots",
-        "x": 2,
-        "y": -2
+        "x": 4,
+        "y": -4
       },
       "type": "xod/patch-nodes/input-port"
     },
@@ -324,8 +389,8 @@
       "label": "CS",
       "position": {
         "units": "slots",
-        "x": 1,
-        "y": -2
+        "x": 3,
+        "y": -4
       },
       "type": "xod/patch-nodes/input-port"
     },
@@ -333,7 +398,7 @@
       "id": "r1ZkM2jvI",
       "position": {
         "units": "slots",
-        "x": 6,
+        "x": 7,
         "y": 1
       },
       "type": "@/write-byte"
@@ -347,8 +412,8 @@
       "label": "ACT",
       "position": {
         "units": "slots",
-        "x": 15,
-        "y": -1
+        "x": 16,
+        "y": -4
       },
       "type": "xod/patch-nodes/input-boolean"
     },
@@ -356,8 +421,8 @@
       "id": "ryFmfhivI",
       "position": {
         "units": "slots",
-        "x": 14,
-        "y": 1
+        "x": 15,
+        "y": -1
       },
       "type": "xod/core/act"
     },

--- a/pack-bools-to-byte/patch.xodp
+++ b/pack-bools-to-byte/patch.xodp
@@ -32,7 +32,7 @@
       "id": "HklS_IoP8",
       "position": {
         "units": "slots",
-        "x": 3,
+        "x": 0,
         "y": 3
       },
       "type": "xod/patch-nodes/output-byte"
@@ -59,7 +59,7 @@
       "id": "SJZQJ3jwI",
       "position": {
         "units": "slots",
-        "x": 8,
+        "x": 7,
         "y": 2
       },
       "type": "xod/patch-nodes/utility"
@@ -95,7 +95,7 @@
       "id": "ryH8OUiP8",
       "position": {
         "units": "slots",
-        "x": 1,
+        "x": 0,
         "y": 2
       },
       "type": "xod/patch-nodes/not-implemented-in-xod"

--- a/project.xod
+++ b/project.xod
@@ -3,5 +3,5 @@
   "description": "XOD library to interface with the Amperka Octofet 8-channel power switches.",
   "license": "AGPL-3",
   "name": "octofet",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/write-byte/patch.xodp
+++ b/write-byte/patch.xodp
@@ -5,7 +5,7 @@
       "id": "BJ101nsvI",
       "position": {
         "units": "slots",
-        "x": 7,
+        "x": 2,
         "y": 0
       },
       "type": "xod/patch-nodes/utility"
@@ -16,7 +16,7 @@
       "label": "DONE",
       "position": {
         "units": "slots",
-        "x": 5,
+        "x": 1,
         "y": 1
       },
       "type": "xod/patch-nodes/output-pulse"
@@ -36,7 +36,7 @@
       "id": "S1_CFknjwL",
       "position": {
         "units": "slots",
-        "x": 2,
+        "x": 0,
         "y": 0
       },
       "type": "xod/patch-nodes/not-implemented-in-xod"
@@ -47,7 +47,7 @@
       "label": "DATA",
       "position": {
         "units": "slots",
-        "x": 5,
+        "x": 1,
         "y": -1
       },
       "type": "xod/patch-nodes/input-byte"
@@ -58,7 +58,7 @@
       "label": "DO",
       "position": {
         "units": "slots",
-        "x": 10,
+        "x": 2,
         "y": -1
       },
       "type": "xod/patch-nodes/input-pulse"

--- a/write/patch.xodp
+++ b/write/patch.xodp
@@ -2,17 +2,6 @@
   "description": "Sets the state (\"on\" or \"off\") of 8 power switches on Octofet board.",
   "links": [
     {
-      "id": "BJAng2sPU",
-      "input": {
-        "nodeId": "B1T-IcyvU",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "HyoFlnswL",
-        "pinKey": "BJeAFkniwU"
-      }
-    },
-    {
       "id": "BJwil3oDL",
       "input": {
         "nodeId": "Skr5g2ivI",
@@ -21,6 +10,17 @@
       "output": {
         "nodeId": "ryxS1Uc1PI",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BkBA98hkD",
+      "input": {
+        "nodeId": "r16acI2kv",
+        "pinKey": "rkrkq821v"
+      },
+      "output": {
+        "nodeId": "HyoFlnswL",
+        "pinKey": "BJeAFkniwU"
       }
     },
     {
@@ -35,28 +35,6 @@
       }
     },
     {
-      "id": "HyDIb3jwL",
-      "input": {
-        "nodeId": "HyoFlnswL",
-        "pinKey": "HJN0K13jPU"
-      },
-      "output": {
-        "nodeId": "ryPr-njw8",
-        "pinKey": "__out__"
-      }
-    },
-    {
-      "id": "S1S3T6nPU",
-      "input": {
-        "nodeId": "S1ldpT3DL",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "HyoFlnswL",
-        "pinKey": "rkoYaT3P8"
-      }
-    },
-    {
       "id": "SJNixnjPI",
       "input": {
         "nodeId": "Skr5g2ivI",
@@ -65,6 +43,39 @@
       "output": {
         "nodeId": "B1gV1LqJvU",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "Sk4CcUhJP",
+      "input": {
+        "nodeId": "B1T-IcyvU",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "r16acI2kv",
+        "pinKey": "ByXryqU2JD"
+      }
+    },
+    {
+      "id": "Sk7A5I3kw",
+      "input": {
+        "nodeId": "S1ldpT3DL",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "r16acI2kv",
+        "pinKey": "H1ouY83Jw"
+      }
+    },
+    {
+      "id": "SkPacU2yw",
+      "input": {
+        "nodeId": "HyoFlnswL",
+        "pinKey": "HJN0K13jPU"
+      },
+      "output": {
+        "nodeId": "rk4pcL2yP",
+        "pinKey": "H1ouY83Jw"
       }
     },
     {
@@ -79,6 +90,17 @@
       }
     },
     {
+      "id": "SkZ0cLhkv",
+      "input": {
+        "nodeId": "r16acI2kv",
+        "pinKey": "H1tOYU2kP"
+      },
+      "output": {
+        "nodeId": "HyoFlnswL",
+        "pinKey": "rkoYaT3P8"
+      }
+    },
+    {
       "id": "SyfoxhoPU",
       "input": {
         "nodeId": "Skr5g2ivI",
@@ -87,6 +109,17 @@
       "output": {
         "nodeId": "HyVk891DI",
         "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SyjTqInyP",
+      "input": {
+        "nodeId": "HyoFlnswL",
+        "pinKey": "rkK0t1hjvU"
+      },
+      "output": {
+        "nodeId": "rk4pcL2yP",
+        "pinKey": "ByXryqU2JD"
       }
     },
     {
@@ -134,6 +167,17 @@
       }
     },
     {
+      "id": "rkcRcI31v",
+      "input": {
+        "nodeId": "rk4pcL2yP",
+        "pinKey": "rkrkq821v"
+      },
+      "output": {
+        "nodeId": "HJLyZ3oPI",
+        "pinKey": "__out__"
+      }
+    },
+    {
       "id": "rkpsxhiDU",
       "input": {
         "nodeId": "Skr5g2ivI",
@@ -145,13 +189,13 @@
       }
     },
     {
-      "id": "ry67ZniD8",
+      "id": "ryLa5In1v",
       "input": {
-        "nodeId": "HyoFlnswL",
-        "pinKey": "rkK0t1hjvU"
+        "nodeId": "rk4pcL2yP",
+        "pinKey": "H1tOYU2kP"
       },
       "output": {
-        "nodeId": "HJLyZ3oPI",
+        "nodeId": "ryPr-njw8",
         "pinKey": "__out__"
       }
     },
@@ -185,7 +229,7 @@
       "label": "DONE",
       "position": {
         "units": "slots",
-        "x": 6,
+        "x": 10,
         "y": 6
       },
       "type": "xod/patch-nodes/output-pulse"
@@ -238,7 +282,7 @@
       "id": "HJLyZ3oPI",
       "position": {
         "units": "slots",
-        "x": 13,
+        "x": 12,
         "y": 2
       },
       "type": "xod/patch-nodes/jumper"
@@ -291,7 +335,7 @@
       "label": "DEV'",
       "position": {
         "units": "slots",
-        "x": 3,
+        "x": 9,
         "y": 6
       },
       "type": "@/output-octofet-device"
@@ -306,15 +350,36 @@
       "type": "@/pack-bools-to-byte"
     },
     {
+      "boundLiterals": {
+        "BkxHk5I2kw": "True"
+      },
+      "id": "r16acI2kv",
+      "position": {
+        "units": "slots",
+        "x": 9,
+        "y": 4
+      },
+      "type": "@/cs-pin-write"
+    },
+    {
       "description": "Triggers a new write.",
       "id": "rJkW89kD8",
       "label": "DO",
       "position": {
         "units": "slots",
-        "x": 13,
+        "x": 12,
         "y": 0
       },
       "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "rk4pcL2yP",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 4
+      },
+      "type": "@/cs-pin-write"
     },
     {
       "id": "ryPr-njw8",


### PR DESCRIPTION
Some changes:
- Fix the CS pin management mistake when Octofets are in a daisy chain. 
The original code:
```
    digitalWrite(_pinCS, LOW);
    // bit stream output
    for (int8_t i = _deviceCount - 1; i >= 0; i--) {
        if (_hardwareSPI)
            SPI.transfer(_deviceChain[i]);
        else
            shiftOut(_pinMOSI, _pinSCK, _bitOrder, _deviceChain[i]);
    }
    // end condition
    digitalWrite(_pinCS, HIGH);
```
Current implementation of the `write-byte` node:
```
    digitalWrite(dev->pinCS, LOW);
    shiftOut(dev->pinMOSI, dev->pinSCK, MSBFIRST, data);
    digitalWrite(dev->pinCS, HIGH);
```
**Regularly pulling the CS line causes false channels actuation for the Octofets in the chain.**

Fixed it by introducing the `cs-pin-write` utility node. As a result, it affects the logic of quickstart nodes `octofet`, `octofet-16`, and `octofet-24`.

- Some visual edits in the arrangement of nodes.

- Removed this artifact:
![22](https://user-images.githubusercontent.com/35202630/87537504-5ff3bf00-c6a3-11ea-984e-11d2ecab9960.jpg)
